### PR TITLE
changed wordle clone link to correct one

### DIFF
--- a/src/components/ProjectLinks/WordleClone/index.js
+++ b/src/components/ProjectLinks/WordleClone/index.js
@@ -23,7 +23,7 @@ export default function WordleClone() {
       </div>
       <div className="p-links">
         <a
-          href="https://cindyung56.github.io/weather-dashboard/"
+          href="https://cindyung56.github.io/wordle-clone/"
           target="_blank"
           rel="noreferrer"
           className="p-link-btn"


### PR DESCRIPTION
Noticed the link to the website in /wordle-clone was redirecting to a previous project, changed it to the correct link