### PR TITLE
edited route path to wordle clone project

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ function App() {
           <Route path="/growing-stars" element={<GrowingStars />} />          
           <Route path="/weather-dashboard" element={<WeatherDashboard />} />
           <Route path="/pokemon-type" element={<TypeIndex />} />
-          <Route path="/wordle-clone" element={<WordleClone />} />
+          <Route path="/wordle-clone-proj" element={<WordleClone />} />
           {/* <Route path="/tech-blog" element={<TechBlog />} /> */}
         </Routes>
       </div>

--- a/src/components/Projects/index.js
+++ b/src/components/Projects/index.js
@@ -44,7 +44,7 @@ export default function Projects() {
               <p>
                 A JavaScript project recreating the popular New York Times game Wordle. Uses animate.css to help with the animations.
               </p>
-              <Link to="/wordle-clone" className="more-info-btn">
+              <Link to="/wordle-clone-proj" className="more-info-btn">
                 MORE INFO
               </Link>
             </div>


### PR DESCRIPTION
Found error with route name /wordle-clone that would redirect to the project which also has the same link upon refresh. To fix this, changed the route name to /wordle-clone-proj